### PR TITLE
Implement basic side panel extension

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,23 @@
+// Service worker for Links & Buttons Finder
+const openTabs = new Set();
+
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.sidePanel.setOptions({ path: 'sidepanel.html', enabled: true });
+});
+
+chrome.action.onClicked.addListener(async (tab) => {
+  const tabId = tab.id;
+  if (openTabs.has(tabId)) {
+    await chrome.sidePanel.close({ tabId });
+    openTabs.delete(tabId);
+  } else {
+    await chrome.sidePanel.open({ tabId });
+    openTabs.add(tabId);
+  }
+});
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
+  if (changeInfo.status === 'complete') {
+    chrome.runtime.sendMessage({ action: 'page-navigated' });
+  }
+});

--- a/content.js
+++ b/content.js
@@ -1,0 +1,19 @@
+// Collect links and buttons on the page
+function collectElements() {
+  const selectors = ['a', 'button', '[role="button"]', '[role="link"]'];
+  const elements = Array.from(document.querySelectorAll(selectors.join(',')));
+  return elements.map((el, index) => {
+    return {
+      id: index,
+      tag: el.tagName.toLowerCase(),
+      text: (el.innerText || '').trim(),
+      href: el.getAttribute('href'),
+    };
+  });
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.action === 'collect') {
+    sendResponse({ elements: collectElements() });
+  }
+});

--- a/faqs.json
+++ b/faqs.json
@@ -1,0 +1,4 @@
+[
+  {"q": "What does this extension do?", "a": "It lists all links and buttons on the current page."}
+]
+

--- a/images.js
+++ b/images.js
@@ -1,0 +1,1 @@
+// Placeholder for future image handling

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Links & Buttons Finder</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; padding: 10px; }
+    section { margin-bottom: 1em; }
+    #resultList li { margin-bottom: 0.5em; }
+  </style>
+</head>
+<body>
+  <section id="summary">
+    <h1>Links & Buttons Finder</h1>
+    <div id="counts">No data loaded.</div>
+    <button id="reload">Reload</button>
+  </section>
+
+  <section id="filters">
+    <h2>Filters</h2>
+    <!-- filter controls to be implemented -->
+  </section>
+
+  <section id="results">
+    <h2>Results</h2>
+    <ul id="resultList"></ul>
+  </section>
+
+  <section id="faqs">
+    <h2>FAQs</h2>
+    <div id="faqContent"></div>
+  </section>
+
+  <script src="sidepanel.js"></script>
+</body>
+</html>

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -1,0 +1,49 @@
+function fetchFaqs() {
+  fetch(chrome.runtime.getURL('faqs.json'))
+    .then(r => r.json())
+    .then(faqs => {
+      const container = document.getElementById('faqContent');
+      container.innerHTML = '';
+      faqs.forEach(faq => {
+        const details = document.createElement('details');
+        const summary = document.createElement('summary');
+        summary.textContent = faq.q;
+        details.appendChild(summary);
+        const p = document.createElement('p');
+        p.textContent = faq.a;
+        details.appendChild(p);
+        container.appendChild(details);
+      });
+    });
+}
+
+function renderResults(data) {
+  const list = document.getElementById('resultList');
+  list.innerHTML = '';
+  data.elements.forEach(item => {
+    const li = document.createElement('li');
+    li.textContent = `[${item.tag}] ${item.text || item.href || ''}`;
+    list.appendChild(li);
+  });
+  document.getElementById('counts').textContent = `Items found: ${data.elements.length}`;
+}
+
+function requestData() {
+  chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+    if (!tabs.length) return;
+    chrome.tabs.sendMessage(tabs[0].id, { action: 'collect' }, renderResults);
+  });
+}
+
+document.getElementById('reload').addEventListener('click', requestData);
+
+chrome.runtime.onMessage.addListener(message => {
+  if (message.action === 'page-navigated') {
+    requestData();
+  }
+});
+
+window.addEventListener('DOMContentLoaded', () => {
+  requestData();
+  fetchFaqs();
+});


### PR DESCRIPTION
## Summary
- implement service worker to manage opening/closing the sidepanel
- add content script collecting links and buttons
- create simple sidepanel HTML with sections for summary, filters, results and FAQs
- provide JS to fetch data and FAQs
- add placeholder `faqs.json` and `images.js`

## Testing
- `npm test` *(fails: Could not read package.json)*